### PR TITLE
Fix deprecated dependency source

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ build --cxxopt='-std=c++14'
 
 build --action_env=PATH="/bin:/usr/bin"
 build --crosstool_top=//common/toolchain:default
-build --jobs 8 --local_ram_resources=HOST_RAM*.5
+build --jobs 8 --ram_utilization_factor 50
 
 build --experimental_strict_action_env
 build --action_env=PATH="/bin:/usr/bin"
@@ -25,7 +25,7 @@ build --crosstool_top=//common/toolchain:default
 build --python_version=PY3
 build --custom_malloc=//common/toolchain:malloc
 build --jobs 8
-build --local_ram_resources=HOST_RAM*.5
+build --ram_utilization_factor 50
 
 # This line doesn't tell our compiler to optimize towards AMD K8. Instead, 'k8' is just an internal
 # name for AMD64/EM64T CPUs. This word is for looking up a proper configuration in

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,7 @@ build --cxxopt='-std=c++14'
 
 build --action_env=PATH="/bin:/usr/bin"
 build --crosstool_top=//common/toolchain:default
-build --jobs 8 --ram_utilization_factor 50
+build --jobs 8 --local_ram_resources=HOST_RAM*.5
 
 build --experimental_strict_action_env
 build --action_env=PATH="/bin:/usr/bin"
@@ -25,7 +25,7 @@ build --crosstool_top=//common/toolchain:default
 build --python_version=PY3
 build --custom_malloc=//common/toolchain:malloc
 build --jobs 8
-build --ram_utilization_factor 50
+build --local_ram_resources=HOST_RAM*.5
 
 # This line doesn't tell our compiler to optimize towards AMD K8. Instead, 'k8' is just an internal
 # name for AMD64/EM64T CPUs. This word is for looking up a proper configuration in

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ pony_http_archive(
 pony_http_archive(
     name = "eigen",
     build_file = "utils/bazel/eigen.BUILD",
-    sha256 = "4286e8f1fabbd74f7ec6ef8ef31c9dbc6102b9248a8f8327b04f5b68da5b05e1",
-    strip_prefix = "eigen-eigen-5a0156e40feb",
-    urls = ["http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"],
+    sha256 = "c5ca6e3442fb48ae75159ca7568854d9ba737bc351460f27ee91b6f3f9fd1f3d",
+    strip_prefix = "eigen-3.3.4",
+    urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.gz"],
 )
 
 # boost


### PR DESCRIPTION
Eigen has moved its repo from BitBucket to GitLab and previous URL and checksum is now invalid. 